### PR TITLE
Reset the Chart colors to Black

### DIFF
--- a/client/src/components/charts/ContactTraceRate.js
+++ b/client/src/components/charts/ContactTraceRate.js
@@ -11,7 +11,7 @@ const ContactTraceRate = (props) => {
             {
                 label: 'Contact Trace Rate',
                 data: stateData,
-                borderColor: 'orange',
+                borderColor: 'black',
                 backgroundColor: 'rgba(0, 0, 0, 0)',
                 fill: true,
                 pointRadius: 0,

--- a/client/src/components/charts/PositiveTestRate.js
+++ b/client/src/components/charts/PositiveTestRate.js
@@ -11,8 +11,8 @@ const PositiveTestRate = (props) => {
             {
                 label: 'Positive test rate',
                 data: positive_test_rate,
-                borderColor: 'green',
-                backgroundColor: 'rgba(0, 255, 0, 0.2)',
+                borderColor: 'black',
+                backgroundColor: 'transparent',
                 fill: true,
                 pointRadius: 0,
                 borderWidth: 4,

--- a/client/src/components/charts/PositiveTestRate.js
+++ b/client/src/components/charts/PositiveTestRate.js
@@ -5,12 +5,16 @@ import "../../App.css";
 
 const PositiveTestRate = (props) => {
     const positive_test_rate = props.data;
-
+    const prepared_data = positive_test_rate.map((item) => {
+        item.y = item.y * 100;
+        return item;
+    })
+    
     const lineData = {
         datasets: [
             {
                 label: 'Positive test rate',
-                data: positive_test_rate,
+                data: prepared_data,
                 borderColor: 'black',
                 backgroundColor: 'transparent',
                 fill: true,
@@ -31,7 +35,7 @@ const PositiveTestRate = (props) => {
             yAxes: [{
                 ticks: {
                     beginAtZero: true,
-                    max: 0.5,
+                    max: 50,
                 },
                 gridLines: {
                     borderDash: [3, 2],
@@ -44,12 +48,21 @@ const PositiveTestRate = (props) => {
         },
         tooltips: {
             intersect: false,
+            titleFontSize: 18,
+            bodyFontSize: 18,
+
             mode: 'index',
             callbacks: {
                 title: function(tooltipItem, chart) {
                     // Change the date format
                     let date = tooltipItem[0].xLabel;
                     return moment(date, 'YYYY MM DD').format('MMMM DD, YYYY');
+                },
+                label: function (tooltipItem, chart) {
+                    return tooltipItem.yLabel + '%';
+                },
+                beforeBody: function (tooltipItem, chart) {
+                    return "Positive Test Rate"
                 }
             }
         },

--- a/client/src/components/charts/ReproductionRate.js
+++ b/client/src/components/charts/ReproductionRate.js
@@ -11,7 +11,7 @@ const ReproductionRate = (props) => {
             {
                 label: 'Reproduction Rate',
                 data: data,
-                borderColor: 'red',
+                borderColor: 'black',
                 backgroundColor: 'rgba(0, 0, 0, 0)',
                 fill: true,
                 pointRadius: 0,


### PR DESCRIPTION
The charts previously had multiple colors for each of the charts but now they are all using the color black.